### PR TITLE
Feature/add claims request support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,34 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+##############################
+## Maven
+##############################
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+pom.xml.bak
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws
+.editorconfig
+
+##############################
+## OS X
+##############################
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.9.3</version>
+            <version>0.9.6</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestHandler.kt
@@ -101,7 +101,7 @@ class CallbackRequestHandler(
         val tokenResponse = _config.getHttpClient()
             .request(_providerConfiguration.tokenEndpoint)
             .contentType(ContentType.X_WWW_FORM_URLENCODED.contentType)
-            .body(HttpRequest.createFormUrlEncodedBodyProcessor(createPostData(requestModel.code, redirectUri)))
+            .body(HttpRequest.createFormUrlEncodedBodyProcessor(requestModel.code?.let { createPostData(it, redirectUri) }))
             .post()
             .response()
 

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/CallbackRequestModel.kt
@@ -22,7 +22,7 @@ class CallbackRequestModel(request: Request)
 {
     val error: String? = request.getQueryParameterValueOrError("error", invalidParameter)
     val errorDescription: String? = request.getQueryParameterValueOrError("error_description", invalidParameter)
-    val code: String = request.getQueryParameterValueOrError("code", invalidParameter)
+    val code: String? = request.getQueryParameterValueOrError("code", invalidParameter)
     val state: String = request.getQueryParameterValueOrError("state", invalidParameter)
 
     fun isError() = error != null|| errorDescription != null

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ShortKeyOidcAuthenticatorRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/authentication/ShortKeyOidcAuthenticatorRequestHandler.kt
@@ -28,6 +28,8 @@ import se.curity.identityserver.sdk.service.ExceptionFactory
 import se.curity.identityserver.sdk.service.authentication.AuthenticatorInformationProvider
 import se.curity.identityserver.sdk.web.Request
 import se.curity.identityserver.sdk.web.Response
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.Optional
 import java.util.UUID
 
@@ -50,7 +52,8 @@ class ShortKeyOidcAuthenticatorRequestHandler(private val _config: ShortKeyOidcA
             }
         }
 
-        _config.getSessionManager().put(Attribute.of("state", state))
+
+        val claims = _config.getClaims().orElse(null)
 
         val queryStringArguments = linkedMapOf<String, Collection<String>>(
             "client_id" to setOf(_config.getClientId()),
@@ -58,7 +61,11 @@ class ShortKeyOidcAuthenticatorRequestHandler(private val _config: ShortKeyOidcA
             "state" to setOf(state),
             "response_type" to setOf("code"),
             "scope" to setOf(scope.joinToString(" "))
-        )
+        ).apply {
+            claims?.let { put("claims", setOf(it))}
+        }
+
+        _config.getSessionManager().put(Attribute.of("state", state))
 
         _logger.debug("Redirecting to {} with query string arguments {}", _providerConfig.authorizeEndpoint,
             queryStringArguments

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/ShortKeyOidcAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/ShortKeyOidcAuthenticatorPluginConfig.kt
@@ -47,6 +47,9 @@ interface ShortKeyOidcAuthenticatorPluginConfig : Configuration {
     @DefaultService
     fun getHttpClient(): HttpClient
 
+    @Description("The claims parameter that are returned at the userinfo endpoint and in the ID token")
+    fun getClaims(): Optional<String>
+
     fun getSessionManager(): SessionManager
 
     fun getExceptionFactory(): ExceptionFactory

--- a/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/ShortKeyOidcAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/authenticator/config/ShortKeyOidcAuthenticatorPluginConfig.kt
@@ -47,7 +47,7 @@ interface ShortKeyOidcAuthenticatorPluginConfig : Configuration {
     @DefaultService
     fun getHttpClient(): HttpClient
 
-    @Description("The claims parameter that are returned at the userinfo endpoint and in the ID token")
+    @Description("The claims that are returned at the userinfo endpoint and in the ID token")
     fun getClaims(): Optional<String>
 
     fun getSessionManager(): SessionManager


### PR DESCRIPTION
- adds support for request of additional user claims that are returned at the userinfo endpoint and in the ID token.
- Upgraded `org.bitbucket.b_c:jose4j` to `0.9.6`  since the current used version `0.9.3` was vulnerable with a HIGH severity [CVE](https://devhub.checkmarx.com/cve-details/CVE-2023-51775/ ) . Didn't spent time on figuring out if the plugin was vulnerable due to this but just upgraded to the latest safe version as a good measure.
